### PR TITLE
Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+  - 3.6
+sudo: required
+services:
+  '- docker'
+script:
+  - 'make test-in-container SELECTORS="--distro fedora-26-x86_64.yaml --multispec-selector version=2.4 --multispec-selector variant=upstream"'

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,0 +1,12 @@
+FROM fedora:26
+
+RUN dnf install -y dnf-plugins-core make golang-github-cpuguy83-go-md2man && \
+    dnf copr enable -y phracek/meta-test-family-devel && \
+    dnf install -y --enablerepo=updates-testing meta-test-family distgen
+# no need to `dnf clean all` since we don't distribute this image
+
+VOLUME /src
+WORKDIR /src
+# we don't need to create an unprivileged user for the test run
+# since we have complete access to docker socket = root on host
+ENTRYPOINT ["make", "test"]

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,10 @@ DG = /usr/bin/dg
 GOMD2MAN = /usr/bin/go-md2man
 DOCKERFILE_SRC := Dockerfile.template
 DOCKERFILE := Dockerfile
+TEST_IMAGE_NAME := container-images-tests
 
-DG_EXEC = ${DG} --max-passes 25 --distro ${DISTRO}.yaml --spec specs/common.yml --multispec specs/multispec.yml --multispec-selector version=${VERSION} --multispec-selector variant=${VARIANT}
+SELECTORS = --distro ${DISTRO}.yaml --multispec-selector version=${VERSION} --multispec-selector variant=${VARIANT}
+DG_EXEC = ${DG} --max-passes 25 --spec specs/common.yml --multispec specs/multispec.yml ${SELECTORS}
 DISTRO_ID = $(shell ${DG_EXEC} --template "{{ config.os.id }}")
 TAG = ${DISTRO_ID}/awesome:${VERSION}
 
@@ -27,7 +29,13 @@ run: build
 	docker run -p 9000:9000 -d ${TAG}
 
 test: build
-	cd tests; VERSION=${VERSION} DISTRO=${DISTRO} DOCKERFILE="../$(DOCKERFILE)" MODULE=docker URL="docker=${TAG}" mtf -l *.py
+	cd tests; VERSION=${VERSION} DISTRO=${DISTRO} DOCKERFILE="../$(DOCKERFILE)" MODULE=docker URL="docker=${TAG}" mtf -l *.py --xunit -
+
+test-in-container: test-image
+	docker run --rm -ti -v /var/run/docker.sock:/var/run/docker.sock:Z -v ${PWD}:/src ${TEST_IMAGE_NAME} "SELECTORS=${SELECTORS}"
+
+test-image:
+	docker build --tag=${TEST_IMAGE_NAME} -f ./Dockerfile.tests .
 
 clean:
 	rm -f $(DOCKERFILE)

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -31,3 +31,7 @@ matrix:
     - distros:
         - fedora-26-x86_64
       version: "2.2"
+    - distros:
+        - fedora-25-x86_64
+        - centos-7-x86_64
+      variant: upstream

--- a/tests/sanity1.py
+++ b/tests/sanity1.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+import json
 import urllib2
 import os
 
@@ -17,7 +18,13 @@ class SanityCheck1(module_framework.AvocadoTest):
 
     def test1(self):
         self.start()
-        r = urllib2.urlopen('http://localhost:{p}'.format(p=self.getConfig()['service']['port']))
+        address = json.loads(
+            self.runHost(
+                "docker container inspect %s" % self.backend.docker_id
+            ).stdout.strip())[0]["NetworkSettings"]["IPAddress"]
+        r = urllib2.urlopen('http://{a}:{p}'.format(
+            a=address,
+            p=self.getConfig()['service']['port']))
         html = r.read()
         self.assertEqual(html, 'I am awesome\n')
 


### PR DESCRIPTION
This adds the ability to run tests from container and also adds `.travis.yml`, which tests the upstream-distributed variant. The assumption is that the downstream variants will be tested in some sort of downstream CI.