### PR TITLE
Use table for environment variables

### DIFF
--- a/help/help.md
+++ b/help/help.md
@@ -30,8 +30,9 @@ Also, describe default configuration options (when defined): hostname, domainnam
 # ENVIRONMENT VARIABLES
 Explain all environment variables available to run the image in different ways without the need of rebuilding the image. Change variables on the docker command line with -e option. For example:
 
-MYSQL_PASSWORD=mypass
-                The password set for the current MySQL user.
+|     Variable name        |       Description                                           |
+| :----------------------- | ------------------------------------------------------ |
+|   MYSQL_PASSWORD=mypass  | The password set for the current MySQL user.           | 
 
 # LABELS
 Describe LABEL settings (from the Dockerfile that created the image) that contains pertinent information.


### PR DESCRIPTION
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>

With the latest version from image-build-tools
```
rpm -qi golang-github-cpuguy83-go-md2man
Name        : golang-github-cpuguy83-go-md2man
Version     : 1.0.7
Release     : 1.fc26
Architecture: x86_64
Install Date: Tue Oct 31 13:20:00 2017
Group       : Unspecified
Size        : 3121760
License     : MIT
Signature   : RSA/SHA256, Tue Sep 19 14:06:19 2017, Key ID 812a6b4b64dab85d
Source RPM  : golang-github-cpuguy83-go-md2man-1.0.7-1.fc26.src.rpm
Build Date  : Tue Sep 19 12:26:19 2017
Build Host  : buildhw-10.phx2.fedoraproject.org
Relocations : (not relocatable)
Packager    : Fedora Project
Vendor      : Fedora Project
URL         : https://github.com/cpuguy83/go-md2man
Summary     : Process markdown into manpages
Description :
go-md2man is a golang tool using blackfriday to process markdown into
manpages.

```

tables are generated properly.

See an output of root/help.1
```
      Some Fedora 26 specific help

ENVIRONMENT VARIABLES
       Explain all environment variables available to run the image in different ways without the need of rebuilding the image. Change
       variables on the docker command line with -e option. For example:

       ┌──────────────────────┬──────────────────────────────────────────────┐
       │Variable name         │ Description                                  │
       ├──────────────────────┼──────────────────────────────────────────────┤
       │MYSQL_PASSWORD=mypass │ The password set for the current MySQL user. │
       └──────────────────────┴──────────────────────────────────────────────┘

LABELS
       Describe LABEL settings (from the Dockerfile that created the image) that contains pertinent information.  For containers run by
       atomic, that could include INSTALL, RUN, UN
```